### PR TITLE
Fix wrong variable name in install_missing_packages(), fixes #68

### DIFF
--- a/install.R
+++ b/install.R
@@ -39,7 +39,7 @@ install_missing_packages = function(pkg, version = NULL, verbose = TRUE){
     }
   }
   if(missingPackage){
-    biocLite(i, suppressUpdates = TRUE)
+    biocLite(pkg, suppressUpdates = TRUE)
   }
 }
 ################################################################################


### PR DESCRIPTION
Thanks for the package. Variable `i` was used instead of `pkg` in `install_missing_packages()`, which caused issue #68 .